### PR TITLE
[readonly, for upstream] fix: gcp lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,47 @@
----
-name: continuous-integration
+name: Continuous Integration
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v2.0.2
+      GOLANGCI_LINT_VERSION: v2.1.6
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # We need to set a cache marker to ensure that the cache is individual for each job.
+      - name: Add Cache Marker
+        run: echo "lint" > env.txt
+
       - name: Set up Go
+        id: install-go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache-dependency-path: |
+            go.sum
+            env.txt
+
+      - name: Download dependencies
+        run: go mod download
+        if: steps.install-go.outputs.cache-hit != 'true'
+
       - name: Lint code
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 
-  build:
+  test:
+    runs-on: ubuntu-latest
     env:
       ATHENS_MONGO_STORAGE_URL: mongodb://localhost:27017
       ATHENS_MINIO_ENDPOINT: http://localhost:9000
@@ -39,12 +55,13 @@ jobs:
       REDIS_SENTINEL_TEST_PROTECTED_MASTER_NAME: protectedredis-1
       ATHENS_PROTECTED_REDIS_PASSWORD: AthensPass1
       GA_PULL_REQUEST: ${{github.event.number}}
-    runs-on: ubuntu-latest
+
     services:
       mongo:
         image: mongo
         ports:
           - 27017:27017
+
       minio:
         image: minio/minio:edge-cicd
         ports:
@@ -52,10 +69,12 @@ jobs:
         env:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123
+
       redis:
         image: redis
         ports:
           - 6379:6379
+
       redis-sentinel:
         image: bitnami/redis-sentinel
         env:
@@ -65,6 +84,7 @@ jobs:
           REDIS_SENTINEL_QUORUM: "1"
         ports:
           - 26379:26379
+
       protectedredis:
         image: bitnami/redis
         ports:
@@ -72,6 +92,7 @@ jobs:
         env:
           REDIS_PORT_NUMBER: 6380
           REDIS_PASSWORD: AthensPass1
+
       redis-sentinel-protected-redis:
         image: bitnami/redis-sentinel
         env:
@@ -83,17 +104,72 @@ jobs:
           REDIS_SENTINEL_PORT_NUMBER: 26380
         ports:
           - 26380:26380
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # We need to set a cache marker to ensure that the cache is individual for each job.
+      - name: Add Cache Marker
+        run: echo "test" > env.txt
+
       - name: Set up Go
+        id: install-go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache-dependency-path: |
+            go.sum
+            env.txt
+
+      - name: Download dependencies
+        run: go mod download
+        if: steps.install-go.outputs.cache-hit != 'true'
+
       - name: Verify changes
         run: make verify
+
       - name: Unit tests
         run: go test -v -race ./...
+
       - name: End to end tests
         if: success() || failure()
         run: make test-e2e
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # We need to set a cache marker to ensure that the cache is individual for each job.
+      - name: Add Cache Marker
+        run: echo "build" > env.txt
+
+      - name: Set up Go
+        id: install-go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: |
+            go.sum
+            env.txt
+
+      - name: Download dependencies
+        run: go mod download
+        if: steps.install-go.outputs.cache-hit != 'true'
+
+      - name: Capture Current Date
+        id: date
+        run: echo "::set-output name=date::$(date -u '+%Y-%m-%d-%H:%M:%S-%Z')"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean --snapshot
+        env:
+          DATE: ${{ steps.date.outputs.date }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,3 @@
----
 name: "CodeQL Security Scanning"
 
 on:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,24 +1,34 @@
----
-name: publish github release artifacts with goreleaser
+name: Publish Build Artifacts
+
 on:
   push:
-    tags: '*'
+    tags:
+      - '*'
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: unshallow
-        run: git fetch --prune --unshallow
-      - name: setup-go
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        id: install-go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: capture current date
+
+      - name: Download dependencies
+        run: go mod download
+        if: steps.install-go.outputs.cache-hit != 'true'
+
+      - name: Capture Current Date
         id: date
         run: echo "::set-output name=date::$(date -u '+%Y-%m-%d-%H:%M:%S-%Z')"
-      - name: goreleaser
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest

--- a/.github/workflows/release.canary.yml
+++ b/.github/workflows/release.canary.yml
@@ -1,8 +1,10 @@
-name: Release canary and commit tags
+name: Release canary
+
 on:
   push:
     branches:
       - main
+
 jobs:
   docker-push-main:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.latest.yml
+++ b/.github/workflows/release.latest.yml
@@ -1,8 +1,10 @@
-name: release-latest
+name: Release Docker Images
+
 on:
   push:
     tags:
       - '**'
+
 jobs:
   docker-push-main:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - exhaustruct
     - forbidigo
     - forcetypeassert
+    - funcorder
     - funlen
     - gochecknoglobals
     - gochecknoinits

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -15,8 +15,9 @@ import (
 
 // Storage implements the (./pkg/storage).Backend interface.
 type Storage struct {
-	bucket         *storage.BucketHandle
-	timeout        time.Duration
+	bucket  *storage.BucketHandle
+	timeout time.Duration
+	// Deprecated: left for config backwards compatibility.
 	staleThreshold time.Duration
 }
 

--- a/pkg/storage/gcp/saver.go
+++ b/pkg/storage/gcp/saver.go
@@ -28,24 +28,11 @@ func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, 
 	const op errors.Op = "gcp.save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
-	gomodPath := config.PackageVersionedName(module, version, "mod")
-	innerErr := s.save(ctx, module, version, mod, zip, info)
-	if errors.Is(innerErr, errors.KindAlreadyExists) {
-		// Cache hit.
-		return errors.E(op, innerErr)
+	err := s.save(ctx, module, version, mod, zip, info)
+	if err != nil {
+		return errors.E(op, err)
 	}
-	// No cache hit. Remove the metadata lock if it is there.
-	inProgress, outerErr := s.checkUploadInProgress(ctx, gomodPath)
-	if outerErr != nil {
-		return errors.E(op, outerErr)
-	}
-	if inProgress {
-		outerErr = s.removeInProgressMetadata(ctx, gomodPath)
-		if outerErr != nil {
-			return errors.E(op, outerErr)
-		}
-	}
-	return innerErr
+	return err
 }
 
 // SetStaleThreshold sets the threshold of how long we consider
@@ -58,107 +45,54 @@ func (s *Storage) save(ctx context.Context, module, version string, mod []byte, 
 	const op errors.Op = "gcp.save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
+
 	gomodPath := config.PackageVersionedName(module, version, "mod")
-	seenAlreadyExists := 0
-	err := s.upload(ctx, gomodPath, bytes.NewReader(mod), true)
-	// If it already exists, check the object metadata to see if the
-	// other two are still uploading in progress somewhere else. If they
-	// are, return a cache hit. If not, continue on to the other two,
-	// and only return a cache hit if all three exist.
-	if errors.Is(err, errors.KindAlreadyExists) {
-		inProgress, progressErr := s.checkUploadInProgress(ctx, gomodPath)
-		if progressErr != nil {
-			return errors.E(op, progressErr)
-		}
-		if inProgress {
-			// err is known to be errors.KindAlreadyExists at this point, so
-			// this is a cache hit return.
-			return errors.E(op, err)
-		}
-		seenAlreadyExists++
-	} else if err != nil {
-		// Other errors
+	err := s.upload(ctx, gomodPath, bytes.NewReader(mod), false)
+	// KindAlreadyExists means the file is uploaded (somewhere else) successfully.
+	if err != nil && !errors.Is(err, errors.KindAlreadyExists) {
 		return errors.E(op, err)
 	}
+
 	zipPath := config.PackageVersionedName(module, version, "zip")
-	err = s.upload(ctx, zipPath, zip, false)
-	if errors.Is(err, errors.KindAlreadyExists) {
-		seenAlreadyExists++
-	} else if err != nil {
+	err = s.upload(ctx, zipPath, zip, true)
+	if err != nil && !errors.Is(err, errors.KindAlreadyExists) {
 		return errors.E(op, err)
 	}
+
 	infoPath := config.PackageVersionedName(module, version, "info")
 	err = s.upload(ctx, infoPath, bytes.NewReader(info), false)
-	// Have all three returned errors.KindAlreadyExists?
-	if errors.Is(err, errors.KindAlreadyExists) {
-		if seenAlreadyExists == 2 {
-			return errors.E(op, err)
-		}
-	} else if err != nil {
+	if err != nil && !errors.Is(err, errors.KindAlreadyExists) {
 		return errors.E(op, err)
 	}
+
 	return nil
 }
 
-func (s *Storage) removeInProgressMetadata(ctx context.Context, gomodPath string) error {
-	const op errors.Op = "gcp.removeInProgressMetadata"
-	ctx, span := observ.StartSpan(ctx, op.String())
-	defer span.End()
-	_, err := s.bucket.Object(gomodPath).Update(ctx, storage.ObjectAttrsToUpdate{
-		Metadata: map[string]string{},
-	})
-	if err != nil {
-		return errors.E(op, err)
-	}
-	return nil
-}
-
-func (s *Storage) checkUploadInProgress(ctx context.Context, gomodPath string) (bool, error) {
-	const op errors.Op = "gcp.checkUploadInProgress"
-	ctx, span := observ.StartSpan(ctx, op.String())
-	defer span.End()
-	attrs, err := s.bucket.Object(gomodPath).Attrs(ctx)
-	if err != nil {
-		return false, errors.E(op, err)
-	}
-	// If we have a config-set lock threshold, i.e. we are using the GCP
-	// slightflight backend, use it. Otherwise, use the fallback, which
-	// is arguably irrelevant when not using GCP for singleflighting.
-	threshold := fallbackInProgressStaleThreshold
-	if s.staleThreshold > 0 {
-		threshold = s.staleThreshold
-	}
-	if attrs.Metadata != nil {
-		_, ok := attrs.Metadata["in_progress"]
-		if ok {
-			// In case the final call to remove the metadata fails for some reason,
-			// we have a threshold after which we consider this to be stale.
-			if time.Since(attrs.Created) > threshold {
-				return false, nil
-			}
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (s *Storage) upload(ctx context.Context, path string, stream io.Reader, first bool) error {
+func (s *Storage) upload(ctx context.Context, path string, stream io.Reader, checkBefore bool) error {
 	const op errors.Op = "gcp.upload"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	if checkBefore {
+		// Check whether the file already exists before uploading.
+		// Note that this is not for preventing the same file from being uploaded multiple times,
+		// but only a small optimization to avoid unnecessary uploads for large files (in particular .zip file).
+		_, err := s.bucket.Object(path).Attrs(cancelCtx)
+		if err == nil {
+			// The file already exists, no need to upload it again.
+			return nil
+		} else if !errors.IsErr(err, storage.ErrObjectNotExist) {
+			// Not expected error, return it.
+			return errors.E(op, err)
+		}
+		// Otherwise, the error is ErrObjectNotExist, so we should upload the file.
+	}
+
 	wc := s.bucket.Object(path).If(storage.Conditions{
 		DoesNotExist: true,
 	}).NewWriter(cancelCtx)
-
-	// We set this metadata only for the first of the three files uploaded,
-	// for use as a singleflight lock.
-	if first {
-		wc.Metadata = make(map[string]string)
-		wc.Metadata["in_progress"] = "true"
-	}
 
 	// NOTE: content type is auto detected on GCP side and ACL defaults to public
 	// Once we support private storage buckets this may need refactoring

--- a/pkg/storage/gcp/saver.go
+++ b/pkg/storage/gcp/saver.go
@@ -13,10 +13,6 @@ import (
 	googleapi "google.golang.org/api/googleapi"
 )
 
-// Fallback for how long we consider an "in_progress" metadata key stale,
-// due to failure to remove it.
-const fallbackInProgressStaleThreshold = 2 * time.Minute
-
 // Save uploads the module's .mod, .zip and .info files for a given version
 // It expects a context, which can be provided using context.Background
 // from the standard library until context has been threaded down the stack.


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

The current implementation of locking in GCP is incorrect, and causes errors instead.

As the background: ideally, saving the 3 files (`.mod`, `.info`, `.zip`) should be atomic; however, Google Cloud Storage does not provide such functionality to write multiple files atomically. Fortunately, Google Cloud Storage does provide us with ways to ensure single file operation is atomic.

For the current implementation, there is a check that when the lock is taken (the upload is in progress), it returns `errors.KindAlreadyExist` which is not correct, because at that moment the files are not yet all uploaded. This makes `stasher.Stash` finish, and when `protocol.Zip` etc. tries to download the file, it will get a file not exists error.

(This link will show as actual code snippet when posted in gomods/athens)
https://github.com/gomods/athens/blob/24895f2a248b6de055d68dac6c6bdfe62cb85fa1/pkg/storage/gcp/saver.go#L73-L77

The solution here can be a spinning lock until the lock is free, so the file will have been downloaded, and proceed to upload the remaining files if the lock becomes stale. However, this adds further complication to the system, and the lock is not needed - I will explain this below.

We can remove the lock in the GCP storage implementation and allow all 3 files to be uploaded, and ignore the error if the file already exists.

* Assuming that there are multiple instances of Athens trying to upload the mod, info and zip file. If the mod file came from one instance and the zip file came from another, there shouldn't be any problem: the result we want is that "a copy of the file exists on GCS", not "the copy of the file on the instance exists on GCS".
* When `Save` returns, it is guaranteed that all 3 files are already uploaded. Therefore, it can safely proceed to download the file.
* Combined with [TODO: fix the link to a PR in gomods/athens] https://github.com/mercari/athens/pull/2, an instance should not try to save the same version of the package multiple times anyway.

## How is the fix applied?

Fully remove the lock in the GCP storage implementation, allowing multiple threads / instances to upload the same files, letting the GCS request precondition provide us with the guarantee that only one file is uploaded.

As a small optimization, check that the ZIP file is not yet stored before attempting to upload.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

No issue yet; we have observed the error in production.

<!-- 
example: Fixes #123
-->
