### PR TITLE
[readonly, for upstream, stacked] Add MD5 checksum to ZIP upload

### DIFF
--- a/cmd/proxy/actions/home.go
+++ b/cmd/proxy/actions/home.go
@@ -47,8 +47,8 @@ const homepage = `<!DOCTYPE html>
 	<pre>GOPROXY={{ .Host }},direct</pre>
 	{{ if .NoSumPatterns }}
 	<h3>Excluding checksum database</h3>
-	<p>Use the following GONOSUM environment variable to exclude checksum database:</p>
-	<pre>GONOSUM={{ .NoSumPatterns }}</pre>
+	<p>Use the following GONOSUMDB environment variable to exclude checksum database:</p>
+	<pre>GONOSUMDB={{ .NoSumPatterns }}</pre>
 	{{ end }}
 
 	<h2>How to use the Athens API</h2>

--- a/docs/content/configuration/home-template.md
+++ b/docs/content/configuration/home-template.md
@@ -61,8 +61,8 @@ For more advanced formatting read more about [Go HTML templates](https://pkg.go.
 	<pre>GOPROXY={{ .Host }},direct</pre>
 	{{ if .NoSumPatterns }}
 	<h3>Excluding checksum database</h3>
-	<p>Use the following GONOSUM environment variable to exclude checksum database:</p>
-	<pre>GONOSUM={{ .NoSumPatterns }}</pre>
+	<p>Use the following GONOSUMDB environment variable to exclude checksum database:</p>
+	<pre>GONOSUMDB={{ .NoSumPatterns }}</pre>
 	{{ end }}
 
 	<h2>How to use the Athens API</h2>

--- a/docs/content/install/shared-team-instance.md
+++ b/docs/content/install/shared-team-instance.md
@@ -128,12 +128,12 @@ Now, we need to clear the local Go modules storage. This is needed so that your 
 
 **Bash**
 ```bash
-sudo rm -fr "$(go env GOPATH)/pkg/mod"
+sudo rm -fr "$(go env GOPATH)/pkg/mod/github.com/athens-artifacts"
 ```
 
 **PowerShell**
 ```powershell
-rm -recurse -force $(go env GOPATH)\pkg\mod
+rm -recurse -force $(go env GOPATH)\pkg\mod\github.com\athens-artifacts
 ```
 
 Now, we can re-run the Athens container:

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	go.mongodb.org/mongo-driver v1.8.3
 	go.opencensus.io v0.24.0
 	golang.org/x/mod v0.17.0
-	golang.org/x/oauth2 v0.23.0
+	golang.org/x/oauth2 v0.27.0
 	golang.org/x/sync v0.12.0
 	google.golang.org/api v0.203.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1601,8 +1601,8 @@ golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/download/list_merge_test.go
+++ b/pkg/download/list_merge_test.go
@@ -127,7 +127,7 @@ func TestListMerge(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, v := range tc.strVersions {
-				s.Save(ctx, testModName, v, bts, io.NopCloser(bytes.NewReader(bts)), bts)
+				s.Save(ctx, testModName, v, bts, io.NopCloser(bytes.NewReader(bts)), nil, bts)
 			}
 			defer clearStorage(s, testModName, tc.strVersions)
 			dp := New(&Opts{s, nil, &listerMock{versions: tc.goVersions, err: tc.goErr}, nil, Strict})

--- a/pkg/download/protocol_test.go
+++ b/pkg/download/protocol_test.go
@@ -165,7 +165,7 @@ func TestListMode(t *testing.T) {
 			networkMode: tc.networkmode,
 		}
 		for _, tag := range tc.storageTags {
-			err := strg.Save(ctx, tc.path, tag, []byte("mod"), bytes.NewReader([]byte("zip")), []byte("info"))
+			err := strg.Save(ctx, tc.path, tag, []byte("mod"), bytes.NewReader([]byte("zip")), nil, []byte("info"))
 			require.NoError(t, err)
 		}
 		t.Run(tc.name, func(t *testing.T) {
@@ -429,7 +429,7 @@ func TestDownloadProtocolWhenFetchFails(t *testing.T) {
 	}
 	fakeMod := testMod{"github.com/athens-artifacts/samplelib", "v1.0.0"}
 	bts := []byte(fakeMod.mod + "@" + fakeMod.ver)
-	err = s.Save(context.Background(), fakeMod.mod, fakeMod.ver, bts, io.NopCloser(bytes.NewReader(bts)), bts)
+	err = s.Save(context.Background(), fakeMod.mod, fakeMod.ver, bts, io.NopCloser(bytes.NewReader(bts)), nil, bts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +472,7 @@ type mockStasher struct {
 }
 
 func (ms *mockStasher) Stash(ctx context.Context, mod string, ver string) (string, error) {
-	err := ms.s.Save(ctx, mod, ver, []byte("mod"), strings.NewReader("zip"), []byte("info"))
+	err := ms.s.Save(ctx, mod, ver, []byte("mod"), strings.NewReader("zip"), nil, []byte("info"))
 	ms.ch <- true // signal async stashing is done
 	return ver, err
 }

--- a/pkg/module/go_get_fetcher.go
+++ b/pkg/module/go_get_fetcher.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gomods/athens/pkg/observ"
 	"github.com/gomods/athens/pkg/storage"
 	"github.com/spf13/afero"
-	"golang.org/x/sync/singleflight"
 )
 
 type goGetFetcher struct {
@@ -22,7 +21,6 @@ type goGetFetcher struct {
 	goBinaryName string
 	envVars      []string
 	gogetDir     string
-	sfg          *singleflight.Group
 }
 
 type goModule struct {
@@ -48,7 +46,6 @@ func NewGoGetFetcher(goBinaryName, gogetDir string, envVars []string, fs afero.F
 		goBinaryName: goBinaryName,
 		envVars:      envVars,
 		gogetDir:     gogetDir,
-		sfg:          &singleflight.Group{},
 	}, nil
 }
 
@@ -59,63 +56,57 @@ func (g *goGetFetcher) Fetch(ctx context.Context, mod, ver string) (*storage.Ver
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 
-	resp, err, _ := g.sfg.Do(mod+"###"+ver, func() (any, error) {
-		// setup the GOPATH
-		goPathRoot, err := afero.TempDir(g.fs, g.gogetDir, "athens")
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-		sourcePath := filepath.Join(goPathRoot, "src")
-		modPath := filepath.Join(sourcePath, getRepoDirName(mod, ver))
-		if err := g.fs.MkdirAll(modPath, os.ModeDir|os.ModePerm); err != nil {
-			_ = clearFiles(g.fs, goPathRoot)
-			return nil, errors.E(op, err)
-		}
-
-		m, err := downloadModule(
-			ctx,
-			g.goBinaryName,
-			g.envVars,
-			goPathRoot,
-			modPath,
-			mod,
-			ver,
-		)
-		if err != nil {
-			_ = clearFiles(g.fs, goPathRoot)
-			return nil, errors.E(op, err)
-		}
-
-		var storageVer storage.Version
-		storageVer.Semver = m.Version
-		info, err := afero.ReadFile(g.fs, m.Info)
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-		storageVer.Info = info
-
-		gomod, err := afero.ReadFile(g.fs, m.GoMod)
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-		storageVer.Mod = gomod
-
-		zip, err := g.fs.Open(m.Zip)
-		if err != nil {
-			return nil, errors.E(op, err)
-		}
-		// note: don't close zip here so that the caller can read directly from disk.
-		//
-		// if we close, then the caller will panic, and the alternative to make this work is
-		// that we read into memory and return an io.ReadCloser that reads out of memory
-		storageVer.Zip = &zipReadCloser{zip, g.fs, goPathRoot}
-
-		return &storageVer, nil
-	})
+	// setup the GOPATH
+	goPathRoot, err := afero.TempDir(g.fs, g.gogetDir, "athens")
 	if err != nil {
-		return nil, err
+		return nil, errors.E(op, err)
 	}
-	return resp.(*storage.Version), nil
+	sourcePath := filepath.Join(goPathRoot, "src")
+	modPath := filepath.Join(sourcePath, getRepoDirName(mod, ver))
+	if err := g.fs.MkdirAll(modPath, os.ModeDir|os.ModePerm); err != nil {
+		_ = clearFiles(g.fs, goPathRoot)
+		return nil, errors.E(op, err)
+	}
+
+	m, err := downloadModule(
+		ctx,
+		g.goBinaryName,
+		g.envVars,
+		goPathRoot,
+		modPath,
+		mod,
+		ver,
+	)
+	if err != nil {
+		_ = clearFiles(g.fs, goPathRoot)
+		return nil, errors.E(op, err)
+	}
+
+	var storageVer storage.Version
+	storageVer.Semver = m.Version
+	info, err := afero.ReadFile(g.fs, m.Info)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	storageVer.Info = info
+
+	gomod, err := afero.ReadFile(g.fs, m.GoMod)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	storageVer.Mod = gomod
+
+	zip, err := g.fs.Open(m.Zip)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	// note: don't close zip here so that the caller can read directly from disk.
+	//
+	// if we close, then the caller will panic, and the alternative to make this work is
+	// that we read into memory and return an io.ReadCloser that reads out of memory
+	storageVer.Zip = &zipReadCloser{zip, g.fs, goPathRoot}
+
+	return &storageVer, nil
 }
 
 // given a filesystem, gopath, repository root, module and version, runs 'go mod download -json'

--- a/pkg/stash/stasher.go
+++ b/pkg/stash/stasher.go
@@ -71,7 +71,7 @@ func (s *stasher) Stash(ctx context.Context, mod, ver string) (string, error) {
 				return v.Semver, nil
 			}
 		}
-		err = s.storage.Save(ctx, mod, v.Semver, v.Mod, v.Zip, v.Info)
+		err = s.storage.Save(ctx, mod, v.Semver, v.Mod, v.Zip, v.ZipMD5, v.Info)
 		if err != nil {
 			return "", errors.E(op, err)
 		}

--- a/pkg/stash/stasher_test.go
+++ b/pkg/stash/stasher_test.go
@@ -84,7 +84,7 @@ type mockStorage struct {
 	existsResponse bool
 }
 
-func (ms *mockStorage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (ms *mockStorage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5 []byte, info []byte) error {
 	ms.saveCalled = true
 	ms.givenVersion = version
 	return nil

--- a/pkg/stash/with_azureblob_test.go
+++ b/pkg/stash/with_azureblob_test.go
@@ -73,6 +73,7 @@ func (ms *mockAzureBlobStasher) Stash(ctx context.Context, mod, ver string) (str
 			ver,
 			[]byte("mod file"),
 			strings.NewReader("zip file"),
+			nil,
 			[]byte("info file"),
 		)
 		if err != nil {

--- a/pkg/stash/with_gcs_test.go
+++ b/pkg/stash/with_gcs_test.go
@@ -119,7 +119,7 @@ func TestWithGCSPartialFailure(t *testing.T) {
 	}
 	s := gs(ms)
 	// We simulate a failure by manually passing an io.Reader that will fail.
-	err = ms.strg.Save(ctx, "stashmod", "v1.0.0", []byte(ms.content), fr, []byte(ms.content))
+	err = ms.strg.Save(ctx, "stashmod", "v1.0.0", []byte(ms.content), fr, nil, []byte(ms.content))
 	if err == nil {
 		// We *want* to fail.
 		t.Fatal(err)
@@ -172,6 +172,7 @@ func (ms *mockGCPStasher) Stash(ctx context.Context, mod, ver string) (string, e
 		ver,
 		[]byte(ms.content),
 		strings.NewReader(ms.content),
+		nil,
 		[]byte(ms.content),
 	)
 	return "", err

--- a/pkg/stash/with_redis_test.go
+++ b/pkg/stash/with_redis_test.go
@@ -210,6 +210,7 @@ func (ms *mockRedisStasher) Stash(ctx context.Context, mod, ver string) (string,
 			ver,
 			[]byte("mod file"),
 			strings.NewReader("zip file"),
+			nil,
 			[]byte("info file"),
 		)
 		if err != nil {

--- a/pkg/storage/azureblob/saver.go
+++ b/pkg/storage/azureblob/saver.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Save implements the (./pkg/storage).Saver interface.
-func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "azureblob.Save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/compliance/benchmarks.go
+++ b/pkg/storage/compliance/benchmarks.go
@@ -33,6 +33,7 @@ func benchList(b *testing.B, s storage.Backend, reset func() error) {
 		version,
 		mock.Mod,
 		mock.Zip,
+		mock.ZipMD5,
 		mock.Info,
 	)
 	require.NoError(b, err, "save for storage failed")
@@ -65,6 +66,7 @@ func benchSave(b *testing.B, s storage.Backend, reset func() error) {
 				version,
 				mock.Mod,
 				bytes.NewReader(zipBts),
+				mock.ZipMD5,
 				mock.Info,
 			)
 			require.NoError(b, err)
@@ -87,7 +89,7 @@ func benchDelete(b *testing.B, s storage.Backend, reset func() error) {
 	b.Run("delete", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			name := fmt.Sprintf("del-%s-%d", module, i)
-			err := s.Save(ctx, name, version, mock.Mod, bytes.NewReader(zipBts), mock.Info)
+			err := s.Save(ctx, name, version, mock.Mod, bytes.NewReader(zipBts), mock.ZipMD5, mock.Info)
 			require.NoError(b, err, "saving %s for storage failed", name)
 			err = s.Delete(ctx, name, version)
 			require.NoError(b, err, "delete failed: %s", name)
@@ -104,7 +106,7 @@ func benchExists(b *testing.B, s storage.Backend, reset func() error) {
 	mock := getMockModule()
 
 	ctx := context.Background()
-	err := s.Save(ctx, module, version, mock.Mod, mock.Zip, mock.Info)
+	err := s.Save(ctx, module, version, mock.Mod, mock.Zip, mock.ZipMD5, mock.Info)
 	require.NoError(b, err)
 
 	b.Run("exists", func(b *testing.B) {

--- a/pkg/storage/external/client.go
+++ b/pkg/storage/external/client.go
@@ -81,7 +81,7 @@ func (s *service) Zip(ctx context.Context, mod, ver string) (storage.SizeReadClo
 	return storage.NewSizer(body, size), nil
 }
 
-func (s *service) Save(ctx context.Context, mod, ver string, modFile []byte, zip io.Reader, info []byte) error {
+func (s *service) Save(ctx context.Context, mod, ver string, modFile []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "external.Save"
 	var err error
 	mod, err = module.EscapePath(mod)

--- a/pkg/storage/external/server.go
+++ b/pkg/storage/external/server.go
@@ -109,7 +109,7 @@ func NewServer(strg storage.Backend) http.Handler {
 			return
 		}
 		defer func() { _ = modZ.Close() }()
-		err = strg.Save(r.Context(), params.Module, params.Version, modFile, modZ, info)
+		err = strg.Save(r.Context(), params.Module, params.Version, modFile, modZ, nil, info)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/storage/fs/saver.go
+++ b/pkg/storage/fs/saver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (s *storageImpl) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (s *storageImpl) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "fs.Save"
 	_, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/gcp/gcp.go
+++ b/pkg/storage/gcp/gcp.go
@@ -15,8 +15,9 @@ import (
 
 // Storage implements the (./pkg/storage).Backend interface.
 type Storage struct {
-	bucket         *storage.BucketHandle
-	timeout        time.Duration
+	bucket  *storage.BucketHandle
+	timeout time.Duration
+	// Deprecated: left for config backwards compatibility.
 	staleThreshold time.Duration
 }
 

--- a/pkg/storage/gcp/saver.go
+++ b/pkg/storage/gcp/saver.go
@@ -13,10 +13,6 @@ import (
 	googleapi "google.golang.org/api/googleapi"
 )
 
-// Fallback for how long we consider an "in_progress" metadata key stale,
-// due to failure to remove it.
-const fallbackInProgressStaleThreshold = 2 * time.Minute
-
 // Save uploads the module's .mod, .zip and .info files for a given version
 // It expects a context, which can be provided using context.Background
 // from the standard library until context has been threaded down the stack.
@@ -28,24 +24,11 @@ func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, 
 	const op errors.Op = "gcp.save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
-	gomodPath := config.PackageVersionedName(module, version, "mod")
-	innerErr := s.save(ctx, module, version, mod, zip, info)
-	if errors.Is(innerErr, errors.KindAlreadyExists) {
-		// Cache hit.
-		return errors.E(op, innerErr)
+	err := s.save(ctx, module, version, mod, zip, info)
+	if err != nil {
+		return errors.E(op, err)
 	}
-	// No cache hit. Remove the metadata lock if it is there.
-	inProgress, outerErr := s.checkUploadInProgress(ctx, gomodPath)
-	if outerErr != nil {
-		return errors.E(op, outerErr)
-	}
-	if inProgress {
-		outerErr = s.removeInProgressMetadata(ctx, gomodPath)
-		if outerErr != nil {
-			return errors.E(op, outerErr)
-		}
-	}
-	return innerErr
+	return err
 }
 
 // SetStaleThreshold sets the threshold of how long we consider
@@ -58,107 +41,54 @@ func (s *Storage) save(ctx context.Context, module, version string, mod []byte, 
 	const op errors.Op = "gcp.save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
+
 	gomodPath := config.PackageVersionedName(module, version, "mod")
-	seenAlreadyExists := 0
-	err := s.upload(ctx, gomodPath, bytes.NewReader(mod), true)
-	// If it already exists, check the object metadata to see if the
-	// other two are still uploading in progress somewhere else. If they
-	// are, return a cache hit. If not, continue on to the other two,
-	// and only return a cache hit if all three exist.
-	if errors.Is(err, errors.KindAlreadyExists) {
-		inProgress, progressErr := s.checkUploadInProgress(ctx, gomodPath)
-		if progressErr != nil {
-			return errors.E(op, progressErr)
-		}
-		if inProgress {
-			// err is known to be errors.KindAlreadyExists at this point, so
-			// this is a cache hit return.
-			return errors.E(op, err)
-		}
-		seenAlreadyExists++
-	} else if err != nil {
-		// Other errors
+	err := s.upload(ctx, gomodPath, bytes.NewReader(mod), false)
+	// KindAlreadyExists means the file is uploaded (somewhere else) successfully.
+	if err != nil && !errors.Is(err, errors.KindAlreadyExists) {
 		return errors.E(op, err)
 	}
+
 	zipPath := config.PackageVersionedName(module, version, "zip")
-	err = s.upload(ctx, zipPath, zip, false)
-	if errors.Is(err, errors.KindAlreadyExists) {
-		seenAlreadyExists++
-	} else if err != nil {
+	err = s.upload(ctx, zipPath, zip, true)
+	if err != nil && !errors.Is(err, errors.KindAlreadyExists) {
 		return errors.E(op, err)
 	}
+
 	infoPath := config.PackageVersionedName(module, version, "info")
 	err = s.upload(ctx, infoPath, bytes.NewReader(info), false)
-	// Have all three returned errors.KindAlreadyExists?
-	if errors.Is(err, errors.KindAlreadyExists) {
-		if seenAlreadyExists == 2 {
-			return errors.E(op, err)
-		}
-	} else if err != nil {
+	if err != nil && !errors.Is(err, errors.KindAlreadyExists) {
 		return errors.E(op, err)
 	}
+
 	return nil
 }
 
-func (s *Storage) removeInProgressMetadata(ctx context.Context, gomodPath string) error {
-	const op errors.Op = "gcp.removeInProgressMetadata"
-	ctx, span := observ.StartSpan(ctx, op.String())
-	defer span.End()
-	_, err := s.bucket.Object(gomodPath).Update(ctx, storage.ObjectAttrsToUpdate{
-		Metadata: map[string]string{},
-	})
-	if err != nil {
-		return errors.E(op, err)
-	}
-	return nil
-}
-
-func (s *Storage) checkUploadInProgress(ctx context.Context, gomodPath string) (bool, error) {
-	const op errors.Op = "gcp.checkUploadInProgress"
-	ctx, span := observ.StartSpan(ctx, op.String())
-	defer span.End()
-	attrs, err := s.bucket.Object(gomodPath).Attrs(ctx)
-	if err != nil {
-		return false, errors.E(op, err)
-	}
-	// If we have a config-set lock threshold, i.e. we are using the GCP
-	// slightflight backend, use it. Otherwise, use the fallback, which
-	// is arguably irrelevant when not using GCP for singleflighting.
-	threshold := fallbackInProgressStaleThreshold
-	if s.staleThreshold > 0 {
-		threshold = s.staleThreshold
-	}
-	if attrs.Metadata != nil {
-		_, ok := attrs.Metadata["in_progress"]
-		if ok {
-			// In case the final call to remove the metadata fails for some reason,
-			// we have a threshold after which we consider this to be stale.
-			if time.Since(attrs.Created) > threshold {
-				return false, nil
-			}
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (s *Storage) upload(ctx context.Context, path string, stream io.Reader, first bool) error {
+func (s *Storage) upload(ctx context.Context, path string, stream io.Reader, checkBefore bool) error {
 	const op errors.Op = "gcp.upload"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	if checkBefore {
+		// Check whether the file already exists before uploading.
+		// Note that this is not for preventing the same file from being uploaded multiple times,
+		// but only a small optimization to avoid unnecessary uploads for large files (in particular .zip file).
+		_, err := s.bucket.Object(path).Attrs(cancelCtx)
+		if err == nil {
+			// The file already exists, no need to upload it again.
+			return nil
+		} else if !errors.IsErr(err, storage.ErrObjectNotExist) {
+			// Not expected error, return it.
+			return errors.E(op, err)
+		}
+		// Otherwise, the error is ErrObjectNotExist, so we should upload the file.
+	}
+
 	wc := s.bucket.Object(path).If(storage.Conditions{
 		DoesNotExist: true,
 	}).NewWriter(cancelCtx)
-
-	// We set this metadata only for the first of the three files uploaded,
-	// for use as a singleflight lock.
-	if first {
-		wc.Metadata = make(map[string]string)
-		wc.Metadata["in_progress"] = "true"
-	}
 
 	// NOTE: content type is auto detected on GCP side and ACL defaults to public
 	// Once we support private storage buckets this may need refactoring

--- a/pkg/storage/minio/saver.go
+++ b/pkg/storage/minio/saver.go
@@ -13,7 +13,7 @@ import (
 	minio "github.com/minio/minio-go/v6"
 )
 
-func (s *storageImpl) Save(ctx context.Context, module, vsn string, mod []byte, zip io.Reader, info []byte) error {
+func (s *storageImpl) Save(ctx context.Context, module, vsn string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "storage.minio.Save"
 	_, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/mongo/mongo_test.go
+++ b/pkg/storage/mongo/mongo_test.go
@@ -59,7 +59,7 @@ func TestQueryModuleVersionExists(t *testing.T) {
 	backend := getStorage(t)
 
 	zipBts, _ := io.ReadAll(mock.Zip)
-	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
+	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.ZipMD5, mock.Info)
 	defer backend.Delete(ctx, modname, ver)
 
 	info, err := query(ctx, backend, modname, ver)
@@ -80,7 +80,7 @@ func TestQueryKindNotFoundErrorCases(t *testing.T) {
 	backend := getStorage(t)
 
 	zipBts, _ := io.ReadAll(mock.Zip)
-	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), mock.Info)
+	backend.Save(ctx, modname, ver, mock.Mod, bytes.NewReader(zipBts), nil, mock.Info)
 	defer backend.Delete(ctx, modname, ver)
 
 	testCases := []struct {

--- a/pkg/storage/mongo/saver.go
+++ b/pkg/storage/mongo/saver.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Save stores a module in mongo storage.
-func (s *ModuleStore) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (s *ModuleStore) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "mongo.Save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/s3/saver.go
+++ b/pkg/storage/s3/saver.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Save implements the (github.com/gomods/athens/pkg/storage).Saver interface.
-func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error {
+func (s *Storage) Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error {
 	const op errors.Op = "s3.Save"
 	ctx, span := observ.StartSpan(ctx, op.String())
 	defer span.End()

--- a/pkg/storage/saver.go
+++ b/pkg/storage/saver.go
@@ -7,5 +7,9 @@ import (
 
 // Saver saves module metadata and its source to underlying storage.
 type Saver interface {
-	Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, info []byte) error
+	// Save saves the module metadata and its source to the storage.
+	//
+	// The caller MAY call zipMD5 with a nil value if the checksum is not available.
+	// The storage implementation MAY use the zipMD5 to verify the integrity of the zip file.
+	Save(ctx context.Context, module, version string, mod []byte, zip io.Reader, zipMD5, info []byte) error
 }

--- a/pkg/storage/version.go
+++ b/pkg/storage/version.go
@@ -6,6 +6,7 @@ import "io"
 type Version struct {
 	Mod    []byte
 	Zip    io.ReadCloser
+	ZipMD5 []byte
 	Info   []byte
 	Semver string
 }


### PR DESCRIPTION
<!-- 
    Welcome, Athenian! Can you do us two quick favors before you submit your PR?
    
    1. Briefly fill out the sections below. It will make it easy for us to review your code
    2. Put "[WIP]" at the beginning of your PR title if you're not ready to have this merged yet (we have a bot that will tell everyone that it's a work in progress)
-->

## What is the problem I am trying to address?

Continuing the GCP storage backend lock removal, this PR aims to prevent regressions in future changes by precomputing the MD5 checksum and passing the checksum when uploading the file.

The computed checksum can be used for any storage provider; however, it is currently only implemented for GCP backend.

## How is the fix applied?

* Further protect against corrupt cache by precomputing the MD5 sum for the ZIP file.
* Modify the `Saver` interface to accept the MD5 sum, and clarify the contract between the Saver implementation and the Saver user regarding the MD5 sum.
* Implement checksum in upload for **GCP** backend only.
    * Other backends have checksum passed to the implementation, but we did not implement passing the checksum to the upload to prevent breaking existing users since we have no way to test those implementations.

## What GitHub issue(s) does this PR fix or close?

<!--
    If it doesn't fix any GitHub Issues, that's ok. Can you please delete the below "Fixes #" line for us? It would help us out a lot. Thanks!

    Your PR might fix one or more GitHub issues. If so, please use the below "Fixes #<issue number>" notation below. If your PR fixes multiple issues, please put multiple lines of "Fixes #<issue number>", one for each issue. If you do that, when this PR is merged, it'll automatically close the issue(s) you reference.
-->

We are facing cache corruption in production.

<!-- 
example: Fixes #123
-->
